### PR TITLE
ConcurrentModificationException fix

### DIFF
--- a/src/main/java/danta/core/templating/AbstractTemplateContentModelImpl.java
+++ b/src/main/java/danta/core/templating/AbstractTemplateContentModelImpl.java
@@ -98,7 +98,6 @@ public abstract class AbstractTemplateContentModelImpl
     public AbstractTemplateContentModelImpl setAsIsolated(final String path, final Object value) {
         return set(path, value, ScopeLocality.ISOLATED);
     }
-
     /**
      * Set Attribute name to value. Attributes are not included in static representations of the ContentModel.
      * For example, a JSON representation provided to clients. They are also not included in any list of model keys or
@@ -218,9 +217,12 @@ public abstract class AbstractTemplateContentModelImpl
     }
 
     private AbstractTemplateContentModelImpl isolateToCurrentScope(final Map<String, Object> isolatedModelData) {
-        currentScopeData().merge(wrap(isolatedModelData));
-        invalidateJSONString();
-        return this;
+        JSONObject currentScopeData = currentScopeData();
+        synchronized (currentScopeData) {
+            currentScopeData().merge(wrap(isolatedModelData));
+            invalidateJSONString();
+            return this;
+        }
     }
 
     private Context rootContext() {


### PR DESCRIPTION
Fixes a ConcurrentModificationException when two or more threads try to access the currentScopeData() object.